### PR TITLE
Add aarch64 to type definitions for m1 compilation

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
@@ -174,7 +174,7 @@ typedef char int1;
 typedef uint4 uintp;
 #endif
 
-#if defined (__APPLE_CC__) && defined (__x86_64__)
+#if defined (__APPLE_CC__) && (defined (__x86_64__)|defined (__aarch64__)|)
 #define HOST_ENDIAN 0
 typedef unsigned int uintm;
 typedef int intm;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
@@ -174,7 +174,7 @@ typedef char int1;
 typedef uint4 uintp;
 #endif
 
-#if defined (__APPLE_CC__) && (defined (__x86_64__)|defined (__aarch64__)|)
+#if defined (__APPLE_CC__) && (defined (__x86_64__)|defined (__aarch64__))
 #define HOST_ENDIAN 0
 typedef unsigned int uintm;
 typedef int intm;

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/types.h
@@ -174,7 +174,7 @@ typedef char int1;
 typedef uint4 uintp;
 #endif
 
-#if defined (__APPLE_CC__) && (defined (__x86_64__)|defined (__aarch64__))
+#if defined (__APPLE_CC__) && (defined (__x86_64__) || defined (__aarch64__))
 #define HOST_ENDIAN 0
 typedef unsigned int uintm;
 typedef int intm;


### PR DESCRIPTION
Currently, 

```
rz-pm -i rz-ghidra
```
Fails on Apple's arm64 due to undefined types.

This fix builds successfully on my M1 Macbook Air.