### PR TITLE
Show noreturn information in function signature

### DIFF
--- a/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.cc
@@ -206,6 +206,14 @@ void EmitXml::tagFuncName(const char *ptr,syntax_highlight hl,
   *s << "</funcname>";
 }
 
+/// \brief Emit a function noreturn identifier
+///
+/// An identifier string representing  noreturn information of the function is emitted
+void EmitXml::tagNoreturn(void)
+{
+  *s << "<noreturn " << highlight[(int4)no_color] << '>' << " noreturn </noreturn>";
+}
+
 /// \brief Emit a data-type identifier
 ///
 /// A string representing the name of a data-type, as appropriate for the source language
@@ -410,6 +418,9 @@ void TokenSplit::print(EmitXml *emit) const
     break;
   case fnam_t:	// tagFuncName
     emit->tagFuncName(tok.c_str(),hl,ptr_second.fd,op);
+    break;
+  case noret_t:
+    emit->tagNoreturn();
     break;
   case type_t:	// tagType
     emit->tagType(tok.c_str(),hl,ptr_second.ct);
@@ -1038,6 +1049,15 @@ void EmitPrettyPrint::tagFuncName(const char *ptr,syntax_highlight hl,const Func
   tok.tagFuncName(ptr,hl,fd,op);
   scan();
 }
+
+void EmitPrettyPrint::tagNoreturn(void)
+{
+  checkstring();
+  TokenSplit &tok( tokqueue.push() );
+  tok.tagNoreturn();
+  scan();
+}
+
 
 void EmitPrettyPrint::tagType(const char *ptr,syntax_highlight hl,const Datatype *ct)
 

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.hh
@@ -316,7 +316,7 @@ public:
     vari_t,		///< A variable identifier
     op_t,		///< An operator
     fnam_t,		///< A function identifier
-    noret_t,  ///< A function noreturn identifier
+    noret_t,		///< A function noreturn identifier
     type_t,		///< A data-type identifier
     field_t,		///< A field name for a structured data-type
     comm_t,		///< Part of a comment block

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.hh
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/prettyprint.hh
@@ -117,6 +117,7 @@ public:
 			    const Varnode *vn,const PcodeOp *op);
   virtual void tagOp(const char *ptr,syntax_highlight hl,const PcodeOp *op);
   virtual void tagFuncName(const char *ptr,syntax_highlight hl,const Funcdata *fd,const PcodeOp *op);
+  virtual void tagNoreturn(void);
   virtual void tagType(const char *ptr,syntax_highlight hl,const Datatype *ct);
   virtual void tagField(const char *ptr,syntax_highlight hl,const Datatype *ct,int4 off);
   virtual void tagComment(const char *ptr,syntax_highlight hl,const AddrSpace *spc,uintb off);
@@ -247,6 +248,8 @@ public:
     *s << ptr; }
   virtual void tagFuncName(const char *ptr,syntax_highlight hl,const Funcdata *fd,const PcodeOp *op) {
     *s << ptr; }
+  virtual void tagNoreturn(void) {
+    *s << " noreturn ";}
   virtual void tagType(const char *ptr,syntax_highlight hl,const Datatype *ct) {
     *s << ptr; }
   virtual void tagField(const char *ptr,syntax_highlight hl,const Datatype *ct,int4 off) {
@@ -313,6 +316,7 @@ public:
     vari_t,		///< A variable identifier
     op_t,		///< An operator
     fnam_t,		///< A function identifier
+    noret_t,  ///< A function noreturn identifier
     type_t,		///< A data-type identifier
     field_t,		///< A field name for a structured data-type
     comm_t,		///< Part of a comment block
@@ -467,6 +471,10 @@ public:
   void tagFuncName(const char *ptr,EmitXml::syntax_highlight h,const Funcdata *f,const PcodeOp *o) {
     tok = ptr; size = tok.size();
     tagtype=fnam_t; delimtype=tokenstring; hl=h; ptr_second.fd=f; op=o; }
+
+  /// \brief Create a function noreturn identifiertoken
+  void tagNoreturn(void) {
+    tagtype=noret_t; delimtype=tokenstring; }
 
   /// \brief Create a data-type identifier token
   ///
@@ -751,6 +759,7 @@ public:
 			   const Varnode *vn,const PcodeOp *op);
   virtual void tagOp(const char *ptr,syntax_highlight hl,const PcodeOp *op);
   virtual void tagFuncName(const char *ptr,syntax_highlight hl,const Funcdata *fd,const PcodeOp *op);
+  virtual void tagNoreturn(void);
   virtual void tagType(const char *ptr,syntax_highlight hl,const Datatype *ct);
   virtual void tagField(const char *ptr,syntax_highlight hl,const Datatype *ct,int4 off);
   virtual void tagComment(const char *ptr,syntax_highlight hl,

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -2286,7 +2286,7 @@ bool PrintC::emitScopeVarDecls(const Scope *scope,int4 cat)
   return notempty;
 }
 
-void PrintC::emitFunctionDeclaration(const Funcdata *fd)
+void PrintC::emitFunctionDeclaration(const Funcdata *fd) 
 {
   const FuncProto *proto = &fd->getFuncProto();
   int4 id = emit->beginFuncProto();
@@ -2304,7 +2304,9 @@ void PrintC::emitFunctionDeclaration(const Funcdata *fd)
   emitSymbolScope(fd->getSymbol());
   emit->tagFuncName(fd->getName().c_str(),EmitXml::funcname_color,
 		    fd,(PcodeOp *)0);
-
+  if (proto->isNoReturn()) {
+    emit->tagNoreturn();
+  }
   emit->spaces(function_call.spacing,function_call.bump);
   int4 id2 = emit->openParen('(');
   emit->spaces(0,function_call.bump);
@@ -2365,7 +2367,7 @@ void PrintC::docFunction(const Funcdata *fd)
     int4 id1 = emit->beginFunction(fd);
     emitCommentFuncHeader(fd);
     emit->tagLine();
-    emitFunctionDeclaration(fd);	// Causes us to enter function's scope
+    emitFunctionDeclaration(fd);	// Causes us to enter function's scope 
     emit->tagLine();
     if (option_newline_after_prototype) {
       emit->tagLine();

--- a/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
+++ b/Ghidra/Features/Decompiler/src/decompile/cpp/printc.cc
@@ -2286,7 +2286,7 @@ bool PrintC::emitScopeVarDecls(const Scope *scope,int4 cat)
   return notempty;
 }
 
-void PrintC::emitFunctionDeclaration(const Funcdata *fd) 
+void PrintC::emitFunctionDeclaration(const Funcdata *fd)
 {
   const FuncProto *proto = &fd->getFuncProto();
   int4 id = emit->beginFuncProto();
@@ -2367,7 +2367,7 @@ void PrintC::docFunction(const Funcdata *fd)
     int4 id1 = emit->beginFunction(fd);
     emitCommentFuncHeader(fd);
     emit->tagLine();
-    emitFunctionDeclaration(fd);	// Causes us to enter function's scope 
+    emitFunctionDeclaration(fd);	// Causes us to enter function's scope
     emit->tagLine();
     if (option_newline_after_prototype) {
       emit->tagLine();


### PR DESCRIPTION
**Detailed description**
Show noreturn attribute  for no return function, adding a `noreturn` tag for printing
the expected output like this:
```c
void sym.imp.exit noreturn (void)
{
    // WARNING: Treating indirect jump as call
    (*_reloc.dyld_stub_binder)();
    return;
}
```
**Test plan:**
seek to a noreturn function and `pdg` to see.


**Closing issue:**
rizinorg/rz-ghidra#86

**Testbin**
[rr.zip](https://github.com/radareorg/r2ghidra-dec/files/3670319/rr.zip)
